### PR TITLE
added default for the f inverse wrt x

### DIFF
--- a/swerve100/src/main/java/org/team100/lib/estimator/TrendEstimator.java
+++ b/swerve100/src/main/java/org/team100/lib/estimator/TrendEstimator.java
@@ -7,7 +7,16 @@ import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Num;
 import edu.wpi.first.math.numbers.N1;
 
-/** State from measurement trend. */
+/**
+ * State from measurement trend.
+ * 
+ * This estimator is a variance-aware version of what I'm sure we would do if
+ * this class didn't exist, which is to estimate velocity via discrete
+ * difference of position. If you want, you could do that without this class
+ * (e.g. some hardware does it), and then you don't need it, you can just treat
+ * velocity measurement as a "real" state measurement, even though there's
+ * really just one sensor.
+ */
 public class TrendEstimator<States extends Num, Inputs extends Num, Outputs extends Num> {
     private final NonlinearPlant<States, Inputs, Outputs> m_plant;
 

--- a/swerve100/src/main/java/org/team100/lib/system/NonlinearPlant.java
+++ b/swerve100/src/main/java/org/team100/lib/system/NonlinearPlant.java
@@ -34,17 +34,29 @@ public interface NonlinearPlant<States extends Num, Inputs extends Num, Outputs 
      * Inverse of f with respect to x, for trending measurement. It's not that
      * important to perfectly invert f; if you get the velocity term, that's
      * probably enough. Use wide variances for unknowns.
+     * 
+     * This partial-inverse is admittedly a strange thing to do, but I don't really
+     * want to take it out, because it illustrates the variance issue with
+     * differencing for velocity estimation. If you're not using the TrendEstimator
+     * then you don't need to implement this method.
      */
-    RandomVector<States> finvWrtX(RandomVector<States> xdot, Matrix<Inputs, N1> u);
+    default RandomVector<States> finvWrtX(RandomVector<States> xdot, Matrix<Inputs, N1> u) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Measurement from state. Use wide variances for unknowns.
      * maybe remove u, since it really is never needed.
+     * 
+     * Usually h is identity, i.e. we can observe the state perfectly.
      */
     RandomVector<Outputs> h(RandomVector<States> x, Matrix<Inputs, N1> u);
 
     /**
-     * Inverse of h with respect to x. Usually both h and hinv are identity.
+     * Inverse of h with respect to x.
+     * 
+     * Usually hinv is identity, which indicates that there is no measurement noise,
+     * which is wrong of course. TODO: add measurement noise.
      */
     RandomVector<States> hinv(RandomVector<Outputs> y, Matrix<Inputs, N1> u);
 


### PR DESCRIPTION
it's used by the trending estimator, which i thought about removing. instead i just added a comment about it, and the default means that if you don't want to deal with it you can just ignore it.